### PR TITLE
Fix to prevent after_switch_callback function from being invoked multiple times

### DIFF
--- a/src/circuit-breaker.coffee
+++ b/src/circuit-breaker.coffee
@@ -8,40 +8,42 @@ class SingleUseCircuitBreaker
   threshold: 4
   decay_timeout: 1000
   switch_timeout: 5000
-  status: 'closed' # or open
   error_checker: null
   decay_rate: 2
 
   debug: (message) -> console.log "Circuit Breaker: #{message}"
 
   constructor: (options) ->
-    options = options || {}
     if typeof options is 'object'
       @[key] = options[key] for key of options 
     @attempts = 0
 
   execute: =>
-    if @exec_args and arguments[0]
+    @execute = ->
       return throw new Error("A circuit breaker cannot be reused with new functions.")
-    unless @exec_args
-      @exec_args = Array.prototype.slice.call(arguments) 
-      @after_switch_callback = if typeof arguments[arguments.length - 1] is 'function' then @exec_args.pop() else @default_after
-      @switch_function = @exec_args.shift() if typeof arguments[0] is 'function'
-      return throw new Error('Must specify the switch function at a minimum.') unless @switch_function
+    after_switch_callback = if typeof arguments[arguments.length - 1] is 'function' then arguments[arguments.length - 1] else @default_after
+    @after_switch_callback = =>
+      @after_switch_callback = -> {}
+      after_switch_callback.apply(@, arguments)
 
+    @switch_function = arguments[0] if typeof arguments[0] is 'function'
+    return throw new Error('Must specify the switch function at a minimum.') unless @switch_function
+    @_execute()
 
+  _execute: =>
     @switch_timer = setTimeout @_handle_timeout, @switch_timeout
     @switch_function(@_handle_switch)
 
-  is_closed: => @status is 'closed'
-  is_open: => @status is 'open'
   default_after: =>
     @debug 'Circuit Breaker: Successful', arguments
+
   cancel: =>
     clearTimeout @decay_timer if @decay_timer
     clearTimeout @switch_timer if @switch_timer
+
   _handle_timeout: =>
     @_handle_switch new CircuitBreakerTimeout()
+
   _handle_switch: (error) =>
     @cancel()
 
@@ -49,16 +51,13 @@ class SingleUseCircuitBreaker
 
     if error
       @debug(error)
-      @status = 'open' if @attempts >= @threshold
+      return @after_switch_callback('open', @) if @attempts >= @threshold
       @attempts += 1
-      @_decay()
+      @decay_timer = setTimeout @_execute, @_decay_time()
     else
       @after_switch_callback.apply(@, arguments)
-  _decay_time: => @decay_timeout * Math.pow(@decay_rate, @attempts)
-  _decay: () =>
-    return @after_switch_callback('open', @) if @is_open()
-    @decay_timer = setTimeout @execute, @_decay_time()
 
+  _decay_time: => @decay_timeout * Math.pow(@decay_rate, @attempts)
 
 
 module.exports = SingleUseCircuitBreaker

--- a/test/breaker.spec.js
+++ b/test/breaker.spec.js
@@ -106,7 +106,18 @@ describe('CircuitBreaker', function(){
     new CircuitBreaker({decay_timeout: 3, debug: logger, error_checker: error_check_fn}).execute(switch_fn, after_fn_no_error)
   })
 
+  it('is not capable of calling the after_fn callback multiple times', function (done) {
+    var switch_fn = function (callback) {
+      setTimeout(callback, 50, null)
+    }
+    var after_fn = sinon.spy();
 
+    new CircuitBreaker({decay_timeout: 3, switch_timeout: 3, debug: function() {}}).execute(switch_fn, after_fn)
 
+    setTimeout(function() {
+      after_fn.should.have.callCount(1)
+      done()
+    }, 200)
+  })
 
 })


### PR DESCRIPTION
- simplified mechanism for preventing execute from being called multiple times
- added mechanism to prevent after_switch_callback from being executed multiple times
- get rid of the 'open'/'close' business since I can't think of a valid use-case